### PR TITLE
Do not process methods without line numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: groovy
 jdk:
-  - oraclejdk7
+  -  oraclejdk8
 env:
   - TERM=dumb
 script:

--- a/jacobo-plugin/src/main/groovy/com/kageiit/jacobo/JacoboTask.groovy
+++ b/jacobo-plugin/src/main/groovy/com/kageiit/jacobo/JacoboTask.groovy
@@ -126,6 +126,10 @@ class JacoboTask extends DefaultTask {
     }
 
     def static method_lines(method, methods, lines) {
+        if (method.@line.isEmpty()) {
+            return []
+        }
+
         def start_line = method.@line.toInteger()
         def larger = methods.findAll { it.@line.toInteger() > start_line }.collect {
             it.@line.toInteger()


### PR DESCRIPTION
Fixes #1

This ignores methods created by bytecode manipulation tools like Lombok and Retrolambda