### PR TITLE
fix for method with missing line number #1

### DIFF
--- a/jacobo-plugin/src/main/groovy/com/kageiit/jacobo/JacoboTask.groovy
+++ b/jacobo-plugin/src/main/groovy/com/kageiit/jacobo/JacoboTask.groovy
@@ -131,12 +131,20 @@ class JacoboTask extends DefaultTask {
         }
 
         def start_line = method.@line.toInteger()
-        def larger = methods.findAll { it.@line.toInteger() > start_line }.collect {
+        def larger = methods.findAll { !it.@line.isEmpty() && it.@line.toInteger() > start_line }.collect {
             it.@line.toInteger()
         }
         def end_line = larger.empty ? 99999999 : larger.min()
 
-        return lines.findAll { start_line <= it.@nr.toInteger() && it.@nr.toInteger() < end_line }
+        def method_lines = lines.findAll { start_line <= it.@nr.toInteger() && it.@nr.toInteger() < end_line }
+
+        // Don't go beyond the number of lines known to be associated with this method
+        def line_counter = method.counter.find { it.@type == LINE }
+        if (!line_counter) {
+            return method_lines
+        }
+        def limit = line_counter.@missed.toInteger() + line_counter.@covered.toInteger()
+        return method_lines.take(limit)
     }
 
     def static fraction(covered, missed) {

--- a/jacobo-plugin/src/test/fixtures/coberturaMissingLineNumber.xml
+++ b/jacobo-plugin/src/test/fixtures/coberturaMissingLineNumber.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage timestamp='1428528104' line-rate='0.8333333333333334' branch-rate='0.5' complexity='4.0'>
+    <sources>
+        <source>src/main/groovy</source>
+    </sources>
+    <packages>
+        <package name='com.kageiit' line-rate='0.8333333333333334' branch-rate='0.5' complexity='4.0'>
+            <classes>
+                <class name='com.kageiit.Jacobo' filename='com/kageiit/Jacobo.java' line-rate='0.8333333333333334' branch-rate='0.5' complexity='4.0'>
+                    <methods>
+                        <method name='&lt;init&gt;' signature='()V' line-rate='1.0' branch-rate='0.0' complexity='1.0'>
+                            <lines>
+                                <line branch='false' number='3' hits='1' />
+                            </lines>
+                        </method>
+                        <method name='foo' signature='()V' line-rate='0.75' branch-rate='0.5' complexity='2.0'>
+                            <lines>
+                                <line branch='true' condition-coverage='50% (1/2)' number='6' hits='1'>
+                                    <conditions>
+                                        <condition number='0' type='jump' coverage='50%' />
+                                    </conditions>
+                                </line>
+                                <line branch='false' number='7' hits='0' />
+                                <line branch='false' number='9' hits='1' />
+                                <line branch='false' number='11' hits='1' />
+                            </lines>
+                        </method>
+                        <method name='bar' signature='()Z' line-rate='0.0' branch-rate='0.0' complexity='1.0'>
+                            <lines/>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line branch='false' number='3' hits='1' />
+                        <line branch='true' condition-coverage='50% (1/2)' number='6' hits='1'>
+                            <conditions>
+                                <condition number='0' type='jump' coverage='50%' />
+                            </conditions>
+                        </line>
+                        <line branch='false' number='7' hits='0' />
+                        <line branch='false' number='9' hits='1' />
+                        <line branch='false' number='11' hits='1' />
+                        <line branch='false' number='14' hits='1' />
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/jacobo-plugin/src/test/fixtures/jacocoMissingLineNumber.xml
+++ b/jacobo-plugin/src/test/fixtures/jacocoMissingLineNumber.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<report name="example">
+    <sessioninfo id="test" start="1428528104869" dump="1428528105940" />
+    <package name="com/kageiit">
+        <class name="com/kageiit/Jacobo">
+            <method name="&lt;init&gt;" desc="()V" line="3">
+                <counter type="INSTRUCTION" missed="0" covered="3" />
+                <counter type="LINE" missed="0" covered="1" />
+                <counter type="COMPLEXITY" missed="0" covered="1" />
+                <counter type="METHOD" missed="0" covered="1" />
+            </method>
+            <method name="foo" desc="()V" line="6">
+                <counter type="INSTRUCTION" missed="3" covered="7" />
+                <counter type="BRANCH" missed="1" covered="1" />
+                <counter type="LINE" missed="1" covered="3" />
+                <counter type="COMPLEXITY" missed="1" covered="1" />
+                <counter type="METHOD" missed="0" covered="1" />
+            </method>
+            <method name="bar" desc="()Z">
+                <counter type="INSTRUCTION" missed="0" covered="2" />
+                <counter type="COMPLEXITY" missed="0" covered="1" />
+                <counter type="METHOD" missed="0" covered="1" />
+            </method>
+            <counter type="INSTRUCTION" missed="3" covered="12" />
+            <counter type="BRANCH" missed="1" covered="1" />
+            <counter type="LINE" missed="1" covered="5" />
+            <counter type="COMPLEXITY" missed="1" covered="3" />
+            <counter type="METHOD" missed="0" covered="3" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </class>
+        <sourcefile name="Jacobo.java">
+            <line nr="3" mi="0" ci="3" mb="0" cb="0" />
+            <line nr="6" mi="0" ci="3" mb="1" cb="1" />
+            <line nr="7" mi="3" ci="0" mb="0" cb="0" />
+            <line nr="9" mi="0" ci="3" mb="0" cb="0" />
+            <line nr="11" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="14" mi="0" ci="2" mb="0" cb="0" />
+            <counter type="INSTRUCTION" missed="3" covered="12" />
+            <counter type="BRANCH" missed="1" covered="1" />
+            <counter type="LINE" missed="1" covered="5" />
+            <counter type="COMPLEXITY" missed="1" covered="3" />
+            <counter type="METHOD" missed="0" covered="3" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </sourcefile>
+        <counter type="INSTRUCTION" missed="3" covered="12" />
+        <counter type="BRANCH" missed="1" covered="1" />
+        <counter type="LINE" missed="1" covered="5" />
+        <counter type="COMPLEXITY" missed="1" covered="3" />
+        <counter type="METHOD" missed="0" covered="3" />
+        <counter type="CLASS" missed="0" covered="1" />
+    </package>
+    <counter type="INSTRUCTION" missed="3" covered="12" />
+    <counter type="BRANCH" missed="1" covered="1" />
+    <counter type="LINE" missed="1" covered="5" />
+    <counter type="COMPLEXITY" missed="1" covered="3" />
+    <counter type="METHOD" missed="0" covered="3" />
+    <counter type="CLASS" missed="0" covered="1" />
+</report>

--- a/jacobo-plugin/src/test/groovy/com/kageiit/robojava/JacoboTaskTest.groovy
+++ b/jacobo-plugin/src/test/groovy/com/kageiit/robojava/JacoboTaskTest.groovy
@@ -59,4 +59,17 @@ class JacoboTaskTest {
         String expected = new File('src/test/fixtures/coberturaFileNames.xml').text.replaceAll("\\s+", "")
         assert converted.equals(expected)
     }
+
+    @Test
+    public void convertWithMissingLineNumber() {
+        jacobo = project.tasks.create("jacobo4", JacoboTask, {
+            it.jacocoReport = new File('src/test/fixtures/jacocoMissingLineNumber.xml')
+            it.coberturaReport = File.createTempFile("temp", ".tmp")
+            it.srcDirs = ['src/main/groovy']
+        })
+        jacobo.convert()
+        String converted = jacobo.coberturaReport.text.replaceAll("\\s+", "")
+        String expected = new File('src/test/fixtures/coberturaMissingLineNumber.xml').text.replaceAll("\\s+", "")
+        assert converted.equals(expected)
+    }
 }


### PR DESCRIPTION
#2 did not fix #1 completely.  This PR addresses 2 additional problems:
1. When a method is encountered, JacoboTask searches through all the methods of the class.  If any of those methods does not have a line number, a `NumberFormatException` is thrown.
2. Given 2 methods, `method1` and `method2`, declared in that order, JacoboTask assumes that any line numbers between method1's starting line number and method2's starting line number belong to method1.  This is not true if method2 does not have a line number associated with it.